### PR TITLE
bugfix: geopoint data needs to be checked before doc ref

### DIFF
--- a/build/lib/FirestoreDocument.js
+++ b/build/lib/FirestoreDocument.js
@@ -171,10 +171,10 @@ var constructDocumentObjectToBackup = exports.constructDocumentObjectToBackup = 
       documentDataToStore = Object.assign({}, documentDataToStore, (0, _defineProperty3.default)({}, key, (0, _types.isNull)(value)));
     } else if ((0, _types.isString)(value)) {
       documentDataToStore = Object.assign({}, documentDataToStore, (0, _defineProperty3.default)({}, key, (0, _types.isString)(value)));
-    } else if ((0, _types.isDocumentReference)(value)) {
-      documentDataToStore = Object.assign({}, documentDataToStore, (0, _defineProperty3.default)({}, key, (0, _types.isDocumentReference)(value)));
     } else if ((0, _types.isGeopoint)(value)) {
       documentDataToStore = Object.assign({}, documentDataToStore, (0, _defineProperty3.default)({}, key, (0, _types.isGeopoint)(value)));
+    } else if ((0, _types.isDocumentReference)(value)) {
+      documentDataToStore = Object.assign({}, documentDataToStore, (0, _defineProperty3.default)({}, key, (0, _types.isDocumentReference)(value)));
     } else {
       console.warn('Unsupported value type for {' + key + ': ' + value + '}');
     }

--- a/lib/FirestoreDocument.js
+++ b/lib/FirestoreDocument.js
@@ -233,15 +233,15 @@ export const constructDocumentObjectToBackup = (
         ...documentDataToStore,
         [key]: isString(value)
       };
-    } else if (isDocumentReference(value)) {
-      documentDataToStore = {
-        ...documentDataToStore,
-        [key]: isDocumentReference(value)
-      };
     } else if (isGeopoint(value)) {
       documentDataToStore = {
         ...documentDataToStore,
         [key]: isGeopoint(value)
+      };
+    } else if (isDocumentReference(value)) {
+      documentDataToStore = {
+        ...documentDataToStore,
+        [key]: isDocumentReference(value)
       };
     } else {
       console.warn(`Unsupported value type for {${key}: ${value}}`);


### PR DESCRIPTION
Hello,

I fixed a bug that occurred when backing up geopoint values.

DocumentReference was being checked before geopoint and was failing due to an undefined type property. Checking geopoint first fixes the issue.

Thanks and  regards,